### PR TITLE
Revamp gallery page: categorized album layout and new styles

### DIFF
--- a/gallery.md
+++ b/gallery.md
@@ -5,60 +5,102 @@ permalink: /gallery/
 ---
 
 <section class="section">
-  <div class="container">
-    <h1 class="h1">Gallery</h1>
-    <p class="lead">A peek into us, our people, and the places we love. Tap any photo to view it larger.</p>
+  <div class="container gallery-page">
+    <header class="album-intro">
+      <p class="album-kicker">Our Photo Album</p>
+      <h1 class="h1">Gallery</h1>
+      <p class="lead">A peek into us, our people, and the places we love. Tap any photo to view it larger.</p>
 
-    <!-- Engagement -->
-    <h2 style="margin-top:1.5rem">Engagement</h2>
-    <div class="masonry" style="margin-top:1rem">
-      <figure class="sr">
-        <a href="{{ '/assets/photos/Engagement.jpg' | relative_url }}">
-          <img src="{{ '/assets/photos/Engagement.jpg' | relative_url }}" alt="Engagement photo of Austin and Jordan" loading="lazy">
-        </a>
-      </figure>
-    </div>
+      <p class="subtle">Flip to a chapter:</p>
+      <nav class="gallery-jump" aria-label="Gallery categories">
+        <a href="#engagement">Engagement</a>
+        <a href="#our-story">Our Story</a>
+        <a href="#venue">Venue</a>
+        <a href="#wedding-week">Wedding Week</a>
+        <a href="#family-friends">Family &amp; Friends</a>
+        <a href="#pets-fun">Pets &amp; Fun</a>
+      </nav>
+    </header>
 
-    <!-- Our Story -->
-    <h2 style="margin-top:2rem">Our Story</h2>
-    <p class="subtle">Snapshots from over the years — trips, cozy weekends, and everything in between.</p>
-    <div class="masonry" style="margin-top:1rem">
-      <!-- Add 'through the years' photos here -->
-    </div>
+    <section id="engagement" class="gallery-category">
+      <div class="category-header">
+        <h2>Engagement</h2>
+        <p class="subtle">Our engagement portraits and favorite moments from this season.</p>
+      </div>
+      <div class="album-grid">
+        <figure class="photo-card sr">
+          <a href="{{ '/assets/photos/Engagement.jpg' | relative_url }}">
+            <img src="{{ '/assets/photos/Engagement.jpg' | relative_url }}" alt="Engagement photo of Austin and Jordan" loading="lazy">
+          </a>
+        </figure>
+      </div>
+    </section>
 
-    <!-- Wedding Festivities -->
-    <h2 style="margin-top:2rem">Wedding Festivities</h2>
-    <p class="subtle">Showers, parties, and little moments around the big day.</p>
-    <div class="masonry" style="margin-top:1rem">
-      <!-- Add festivities photos here -->
-    </div>
+    <section id="our-story" class="gallery-category">
+      <div class="category-header">
+        <h2>Our Story</h2>
+        <p class="subtle">Snapshots from over the years — trips, cozy weekends, and everything in between.</p>
+      </div>
+      <div class="album-grid">
+        <!-- Add through-the-years photos here -->
+      </div>
+      <p class="gallery-note">Album ideas: <strong>Travel Adventures</strong>, <strong>Date Nights</strong>, <strong>Holiday Traditions</strong>.</p>
+    </section>
 
-    <!-- Venue -->
-    <h2 style="margin-top:2rem">Venue</h2>
-    <p class="subtle">Scenes from Cedar Oaks Farm and the surrounding beauty.</p>
-    <div class="masonry" style="margin-top:1rem">
-      <figure class="sr">
-        <a href="{{ '/assets/photos/Vineyard.jpg' | relative_url }}">
-          <img src="{{ '/assets/photos/Vineyard.jpg' | relative_url }}" alt="Vineyard and mountain views near the venue" loading="lazy">
-        </a>
-      </figure>
-    </div>
+    <section id="venue" class="gallery-category">
+      <div class="category-header">
+        <h2>Venue</h2>
+        <p class="subtle">Scenes from Cedar Oaks Farm and the surrounding beauty.</p>
+      </div>
+      <div class="album-grid">
+        <figure class="photo-card sr">
+          <a href="{{ '/assets/photos/Vineyard.jpg' | relative_url }}">
+            <img src="{{ '/assets/photos/Vineyard.jpg' | relative_url }}" alt="Vineyard and mountain views near the venue" loading="lazy">
+          </a>
+        </figure>
+      </div>
+    </section>
 
-    <!-- Just for Fun -->
-    <h2 style="margin-top:2rem">Just for Fun</h2>
-    <p class="subtle">The furry family + outtakes we love.</p>
-    <div class="masonry" style="margin-top:1rem">
-      <figure class="sr">
-        <a href="{{ '/assets/photos/Pretzel.jpg' | relative_url }}">
-          <img src="{{ '/assets/photos/Pretzel.jpg' | relative_url }}" alt="Pretzel the Bernadoodle being adorable" loading="lazy">
-        </a>
-      </figure>
-      <figure class="sr">
-        <a href="{{ '/assets/photos/Stormy.jpg' | relative_url }}">
-          <img src="{{ '/assets/photos/Stormy.jpg' | relative_url }}" alt="Stormy striking a pose" loading="lazy">
-        </a>
-      </figure>
-    </div>
+    <section id="wedding-week" class="gallery-category">
+      <div class="category-header">
+        <h2>Wedding Week</h2>
+        <p class="subtle">Showers, rehearsal dinner, getting-ready moments, and celebration details.</p>
+      </div>
+      <div class="album-grid">
+        <!-- Add wedding week photos here -->
+      </div>
+      <p class="gallery-note">Album ideas: <strong>Bridal Shower</strong>, <strong>Rehearsal Dinner</strong>, <strong>Behind the Scenes</strong>.</p>
+    </section>
 
+    <section id="family-friends" class="gallery-category">
+      <div class="category-header">
+        <h2>Family &amp; Friends</h2>
+        <p class="subtle">The people who helped shape our story.</p>
+      </div>
+      <div class="album-grid">
+        <!-- Add family and friends photos here -->
+      </div>
+      <p class="gallery-note">Album ideas: <strong>Childhood Throwbacks</strong>, <strong>Best Friends</strong>, <strong>Family Celebrations</strong>.</p>
+    </section>
+
+    <section id="pets-fun" class="gallery-category">
+      <div class="category-header">
+        <h2>Pets &amp; Fun</h2>
+        <p class="subtle">The furry family + playful outtakes we love.</p>
+      </div>
+      <div class="album-grid">
+        <figure class="photo-card sr">
+          <a href="{{ '/assets/photos/Pretzel.jpg' | relative_url }}">
+            <img src="{{ '/assets/photos/Pretzel.jpg' | relative_url }}" alt="Pretzel the Bernadoodle being adorable" loading="lazy">
+          </a>
+        </figure>
+        <figure class="photo-card sr tilt-right">
+          <a href="{{ '/assets/photos/Stormy.jpg' | relative_url }}">
+            <img src="{{ '/assets/photos/Stormy.jpg' | relative_url }}" alt="Stormy striking a pose" loading="lazy">
+          </a>
+        </figure>
+      </div>
+      <p class="gallery-note">Album ideas: <strong>Pet Portraits</strong>, <strong>Blooper Reel</strong>, <strong>Weekend Adventures</strong>.</p>
+    </section>
   </div>
 </section>

--- a/styles.css
+++ b/styles.css
@@ -150,11 +150,116 @@ a.btn.ghost:hover { background: var(--brand-600); color:#fff; }
 .ac-item.open .ac-header{ background:#f7fbf8; }
 
 /* Gallery */
-.masonry{ column-count: 3; column-gap: 1rem; }
-.masonry figure{ break-inside: avoid; margin:0 0 1rem; border-radius: 12px; overflow:hidden; border:1px solid var(--border); box-shadow: var(--shadow); }
-.masonry img{ width:100%; height:auto; display:block; }
-@media (max-width: 900px){ .masonry{ column-count:2; } }
-@media (max-width: 600px){ .masonry{ column-count:1; } }
+.gallery-page {
+  max-width: 1080px;
+}
+.album-intro {
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto 1.5rem;
+  background: linear-gradient(180deg, #fff, #fdf8fa);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: var(--shadow);
+}
+.album-kicker {
+  margin: 0;
+  color: var(--brand-600);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-size: .75rem;
+  font-weight: 700;
+}
+.gallery-jump {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: .55rem;
+  margin: .65rem 0 0;
+}
+.gallery-jump a {
+  display: inline-flex;
+  align-items: center;
+  padding: .45rem .8rem;
+  border: 1px solid #e7d5dc;
+  border-radius: 999px;
+  background: #fff;
+  color: #7a5b64;
+  font-size: .92rem;
+  transition: .2s ease;
+}
+.gallery-jump a:hover {
+  transform: translateY(-1px);
+  background: #fff3f7;
+  border-color: var(--accent);
+  color: var(--ink);
+}
+.gallery-category {
+  margin: 1.4rem 0;
+  padding: 1rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, .92);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+.category-header {
+  text-align: center;
+  margin-bottom: .9rem;
+}
+.category-header h2 {
+  margin: 0;
+  font-family: ui-serif, Georgia, serif;
+}
+.category-header .subtle {
+  margin: .2rem 0 0;
+}
+.album-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  justify-items: center;
+}
+.photo-card {
+  width: min(100%, 300px);
+  margin: 0;
+  padding: .6rem .6rem 1rem;
+  background: #fff;
+  border: 1px solid #f0dce3;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .08);
+  transform: rotate(-1.2deg);
+}
+.photo-card:nth-child(even) {
+  transform: rotate(1deg);
+}
+.photo-card.tilt-right {
+  transform: rotate(1.8deg);
+}
+.photo-card a {
+  display: block;
+  border-radius: 10px;
+  overflow: hidden;
+}
+.photo-card img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.gallery-note {
+  text-align: center;
+  margin: .9rem 0 .1rem;
+  color: var(--muted);
+  font-size: .95rem;
+}
+
+@media (max-width: 640px){
+  .album-intro,
+  .gallery-category {
+    border-radius: 16px;
+    padding: .9rem;
+  }
+}
 
 /* Forms */
 form { max-width: 720px; margin: 0 auto; }


### PR DESCRIPTION
### Motivation
- Modernize the gallery page to present photos as organized albums instead of a single masonry block.
- Improve discoverability with quick-jump navigation and clearer category headings.
- Make the gallery responsive and visually cohesive with card-style photo tiles and subtle UI polish.

### Description
- Reworked `gallery.md` to add an `album-intro` header, a `gallery-jump` nav, and separate sections for `#engagement`, `#our-story`, `#venue`, `#wedding-week`, `#family-friends`, and `#pets-fun` with placeholder content and notes.
- Replaced the old `.masonry` markup and one-column/column-count approach with semantic `gallery-category`, `album-grid`, and `photo-card` elements and updated image markup for consistency.
- Added comprehensive CSS in `styles.css` to support `.gallery-page`, `.album-intro`, `.gallery-jump`, `.gallery-category`, `.album-grid`, `.photo-card`, responsive rules, and gallery-specific utilities, and removed the previous masonry rules.
- Preserved existing image references and `relative_url` usage while enhancing layout, borders, shadows, and small tilt effects for photo cards.

### Testing
- Ran a local site build with `jekyll build`, which completed without errors.
- Linted the stylesheet with `stylelint styles.css` and received no reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c3a81a908331a90a64c5d5ef6233)